### PR TITLE
Fixing bug involving extra bins appearing after compound tiling feature was introduced

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,9 +91,9 @@ val vExtractor = new ValueExtractor[Double] {
 
 // A series ties the value extractors, projection and bin/tile aggregators together.
 // We'll be tiling average passengers per bin, and max/min of the bin averages per tile
-// We'll also divide our tiles into 32x32 bins so that the output is readable, but
-// feel free to generate tiles at any resolution
-val series = new Series((32, 32), cExtractor, projection, Some(vExtractor), MeanAggregator, Some(MinMaxAggregator))
+// We'll also divide our tiles into 32x32 bins so that the output is readable. We specify
+// this using the maximum possible bin index, which is (31,31)
+val series = new Series((31, 31), cExtractor, projection, Some(vExtractor), MeanAggregator, Some(MinMaxAggregator))
 
 // which tiles are we generating?
 val request = new TileSeqRequest(Seq((0,0,0), (1,0,0)), projection)

--- a/src/main/scala/com/unchartedsoftware/mosaic/core/generation/Series.scala
+++ b/src/main/scala/com/unchartedsoftware/mosaic/core/generation/Series.scala
@@ -15,6 +15,7 @@ import scala.reflect.ClassTag
  *                            ValueExtractor --------^
  * Multiple series are meant to be tiled by a TileGenerator simultaneously
  *
+ * @param maxBin The maximum possible bin index (i.e. if your tile is 256x256, this would be (255,255))
  * @param cExtractor a mechanism for grabbing the data-space coordinates from a source record
  * @param projection the  projection from data to some space (i.e. 2D or 1D)
  * @param vExtractor a mechanism for grabbing or synthesizing the "value" column from a source record (optional)
@@ -31,7 +32,7 @@ import scala.reflect.ClassTag
  * @tparam X Output data type for tile aggregators
  */
 class Series[DC, TC, BC, T, U, V, W, X](
-  val tileSize: BC,
+  val maxBin: BC,
   val cExtractor: ValueExtractor[DC],
   val projection: Projection[DC,TC,BC],
   val vExtractor: Option[ValueExtractor[T]],

--- a/src/main/scala/com/unchartedsoftware/mosaic/core/generation/mapreduce/MapReduceTileGenerator.scala
+++ b/src/main/scala/com/unchartedsoftware/mosaic/core/generation/mapreduce/MapReduceTileGenerator.scala
@@ -150,7 +150,7 @@ private class MapReduceTileGeneratorCombiner[TC](
 private class MapReduceSeriesWrapper[DC, TC, BC, T, U: ClassTag, V, W: ClassTag, X](
   series: Series[DC, TC, BC, T, U, V, W, X])(implicit tileIntermediateManifest: Manifest[W]) extends Serializable {
 
-  private val maxBins = series.projection.binTo1D(series.tileSize, series.tileSize)
+  private val maxBins = series.projection.binTo1D(series.maxBin, series.maxBin)+1
 
   /**
    * Combines cExtractor with projection to produce an intermediate
@@ -161,7 +161,7 @@ private class MapReduceSeriesWrapper[DC, TC, BC, T, U: ClassTag, V, W: ClassTag,
    * @return Option[(TC, (Int, Option[T]))] a tile coordinate along with the 1D bin index and the extracted value column
    */
   def projectAndTransform(row: Row, z: Int): Option[(TC, (Int, Option[T]))] = {
-    val coord = series.projection.project(series.cExtractor.rowToValue(row), z, series.tileSize)
+    val coord = series.projection.project(series.cExtractor.rowToValue(row), z, series.maxBin)
     if (coord.isDefined) {
       val value: Option[T] = series.vExtractor match {
         case None => None
@@ -169,7 +169,7 @@ private class MapReduceSeriesWrapper[DC, TC, BC, T, U: ClassTag, V, W: ClassTag,
       }
       Some(
         (coord.get._1,
-          (series.projection.binTo1D(coord.get._2, series.tileSize),value)
+          (series.projection.binTo1D(coord.get._2, series.maxBin),value)
         )
       )
     } else {

--- a/src/main/scala/com/unchartedsoftware/mosaic/core/projection/Projection.scala
+++ b/src/main/scala/com/unchartedsoftware/mosaic/core/projection/Projection.scala
@@ -26,7 +26,7 @@ abstract class Projection[DC, TC, BC](
    * Project a data-space coordinate into the corresponding tile coordinate and bin coordinate
    * @param dc the data-space coordinate
    * @param z the zoom level
-   * @param maxBin the size of a tile
+   * @param maxBin The maximum possible bin index (i.e. if your tile is 256x256, this would be (255,255))
    * @return Some[(TC, Int)] representing the tile coordinate and bin index if the given row is within the bounds of the viz. None otherwise.
    */
   def project(dc: Option[DC], z: Int, maxBin: BC): Option[(TC, BC)]
@@ -34,7 +34,7 @@ abstract class Projection[DC, TC, BC](
   /**
    * Project a bin index BC into 1 dimension for easy storage of bin values in an array
    * @param bin A bin index
-   * @param maxBin The maximum possible bin index
+   * @param maxBin The maximum possible bin index (i.e. if your tile is 256x256, this would be (255,255))
    * @return the bin index converted into its one-dimensional representation
    */
   def binTo1D(bin: BC, maxBin: BC): Int

--- a/src/main/scala/com/unchartedsoftware/mosaic/core/projection/numeric/CartesianProjection.scala
+++ b/src/main/scala/com/unchartedsoftware/mosaic/core/projection/numeric/CartesianProjection.scala
@@ -54,14 +54,14 @@ class CartesianProjection(
         var howFarY = scaledDataY * tileCounts(z)
         var x = howFarX.toInt
         var y = howFarY.toInt
-        var xBin = ((howFarX - x)*maxBin._1).toInt
-        var yBin = (maxBin._2-1) - ((howFarY - y)*maxBin._2).toInt
+        var xBin = ((howFarX - x)*(maxBin._1+1)).toInt
+        var yBin = (maxBin._2) - ((howFarY - y)*(maxBin._2+1)).toInt
         Some(((z, x, y), (xBin, yBin)))
       }
     }
   }
 
   override def binTo1D(bin: (Int, Int), maxBin: (Int, Int)): Int = {
-    bin._1 + bin._2*maxBin._1
+    bin._1 + bin._2*(maxBin._1+1)
   }
 }

--- a/src/main/scala/com/unchartedsoftware/mosaic/core/projection/numeric/MercatorProjection.scala
+++ b/src/main/scala/com/unchartedsoftware/mosaic/core/projection/numeric/MercatorProjection.scala
@@ -57,8 +57,8 @@ class MercatorProjection(
         val x = howFarX.toInt
         val y = howFarY.toInt
 
-        var xBin = ((howFarX - x)*maxBin._1).toInt
-        var yBin = (maxBin._2-1) - ((howFarY - y)*maxBin._2).toInt
+        var xBin = ((howFarX - x)*(maxBin._1+1)).toInt
+        var yBin = (maxBin._2) - ((howFarY - y)*(maxBin._2+1)).toInt
 
         Some(((z, x, y), (xBin, yBin)))
       }
@@ -66,6 +66,6 @@ class MercatorProjection(
   }
 
   override def binTo1D(bin: (Int, Int), maxBin: (Int, Int)): Int = {
-    bin._1 + bin._2*maxBin._1
+    bin._1 + bin._2*(maxBin._1+1)
   }
 }

--- a/src/main/scala/com/unchartedsoftware/mosaic/core/projection/numeric/SeriesProjection.scala
+++ b/src/main/scala/com/unchartedsoftware/mosaic/core/projection/numeric/SeriesProjection.scala
@@ -47,7 +47,7 @@ class SeriesProjection(
         //compute all tile/bin coordinates (z, x, y, bX, bY)
         var howFarX = scaledDataX * tileCounts(z)
         var x = howFarX.toInt
-        var xBin = ((howFarX - x)*maxBin).toInt
+        var xBin = ((howFarX - x)*(maxBin+1)).toInt
         Some(((z, x), xBin))
       }
     }

--- a/src/test/scala/com/unchartedsoftware/mosaic/core/projection/numeric/CartesianProjectionSpec.scala
+++ b/src/test/scala/com/unchartedsoftware/mosaic/core/projection/numeric/CartesianProjectionSpec.scala
@@ -48,7 +48,7 @@ class CartesianProjectionSpec extends FunSpec {
         //fuzz inputs
         for (i <- 0 until 100) {
           val row = Some((Math.random, Math.random))
-          val coords = projection.project(row, 0, (100, 100))
+          val coords = projection.project(row, 0, (99, 99))
           assert(coords.isDefined)
 
           //check zoom level
@@ -60,9 +60,10 @@ class CartesianProjectionSpec extends FunSpec {
 
           //check bin
           val xBin = (row.get._1*100).toInt;
-          val yBin = (100-1) - (row.get._2*100).toInt;
+          val yBin = (99) - (row.get._2*100).toInt;
           assert(coords.get._2._1 === xBin, "check x bin index for " + row.toString)
           assert(coords.get._2._2 === yBin, "check y bin index for " + row.toString)
+          assert(coords.get._2._1*coords.get._2._2 < 100*100)
         }
       }
 
@@ -71,7 +72,7 @@ class CartesianProjectionSpec extends FunSpec {
         //fuzz inputs
         for (i <- 0 until 100) {
           val row = Some((Math.random, Math.random))
-          val coords = projection.project(row, 1, (100, 100))
+          val coords = projection.project(row, 1, (99, 99))
           assert(coords.isDefined)
 
           //check zoom level
@@ -83,9 +84,10 @@ class CartesianProjectionSpec extends FunSpec {
 
           //check bin
           val xBin = ((row.get._1*200) % 100).toInt
-          val yBin = (100 - 1) - ((row.get._2*200) % 100).toInt
+          val yBin = (99) - ((row.get._2*200) % 100).toInt
           assert(coords.get._2._1 === xBin, "check x bin index for " + row.toString)
           assert(coords.get._2._2 === yBin, "check y bin index for " + row.toString)
+          assert(coords.get._2._1*coords.get._2._2 < 100*100)
         }
       }
     }
@@ -97,7 +99,9 @@ class CartesianProjectionSpec extends FunSpec {
         //fuzz inputs
         for (i <- 0 until 100) {
           val bin = (Math.round(Math.random*99).toInt, Math.round(Math.random*99).toInt)
-          assert(projection.binTo1D(bin, (100,100)) === bin._1 + bin._2*100)
+          val unidim = projection.binTo1D(bin, (99,99))
+          assert(unidim <= 100*100)
+          assert(unidim === bin._1 + bin._2*100)
         }
       }
     }

--- a/src/test/scala/com/unchartedsoftware/mosaic/core/projection/numeric/MercatorProjectionSpec.scala
+++ b/src/test/scala/com/unchartedsoftware/mosaic/core/projection/numeric/MercatorProjectionSpec.scala
@@ -48,7 +48,7 @@ class MercatorProjectionSpec extends FunSpec {
         //fuzz inputs
         for (i <- 0 until 100) {
           val row = Some((Math.random*360-180, Math.random*170-85))
-          val coords = projection.project(row, 0, (100, 100))
+          val coords = projection.project(row, 0, (99, 99))
           assert(coords.isDefined)
 
           //check zoom level
@@ -66,7 +66,7 @@ class MercatorProjectionSpec extends FunSpec {
           val y = howFarY.toInt
 
           var xBin = ((howFarX - x)*100).toInt
-          var yBin = (100-1) - ((howFarY - y)*100).toInt
+          var yBin = (99) - ((howFarY - y)*100).toInt
 
           //check coordinates
           assert(coords.get._1._2 === x, "check coordinates")
@@ -75,6 +75,7 @@ class MercatorProjectionSpec extends FunSpec {
           //check bin
           assert(coords.get._2._1 === xBin, "check x bin index for " + row.toString)
           assert(coords.get._2._2 === yBin, "check y bin index for " + row.toString)
+          assert(coords.get._2._1*coords.get._2._2 < 100*100)
         }
       }
 
@@ -83,7 +84,7 @@ class MercatorProjectionSpec extends FunSpec {
         //fuzz inputs
         for (i <- 0 until 100) {
           val row = Some((Math.random*360-180, Math.random*170-85))
-          val coords = projection.project(row, 1, (100, 100))
+          val coords = projection.project(row, 1, (99, 99))
           assert(coords.isDefined)
 
           //check zoom level
@@ -101,7 +102,7 @@ class MercatorProjectionSpec extends FunSpec {
           val y = howFarY.toInt
 
           var xBin = ((howFarX - x)*100).toInt
-          var yBin = (100-1) - ((howFarY - y)*100).toInt
+          var yBin = (99) - ((howFarY - y)*100).toInt
 
           //check coordinates
           assert(coords.get._1._2 === x, "check coordinates")
@@ -110,6 +111,7 @@ class MercatorProjectionSpec extends FunSpec {
           //check bin
           assert(coords.get._2._1 === xBin, "check x bin index for " + row.toString)
           assert(coords.get._2._2 === yBin, "check y bin index for " + row.toString)
+          assert(coords.get._2._1*coords.get._2._2 < 100*100)
         }
       }
     }
@@ -121,7 +123,9 @@ class MercatorProjectionSpec extends FunSpec {
         //fuzz inputs
         for (i <- 0 until 100) {
           val bin = (Math.round(Math.random*99).toInt, Math.round(Math.random*99).toInt)
-          assert(projection.binTo1D(bin, (100,100)) === bin._1 + bin._2*100)
+          val unidim = projection.binTo1D(bin, (99,99))
+          assert(unidim <= 100*100)
+          assert(unidim === bin._1 + bin._2*100)
         }
       }
     }

--- a/src/test/scala/com/unchartedsoftware/mosaic/core/projection/numeric/SeriesProjectionSpec.scala
+++ b/src/test/scala/com/unchartedsoftware/mosaic/core/projection/numeric/SeriesProjectionSpec.scala
@@ -41,7 +41,7 @@ class SeriesProjectionSpec extends FunSpec {
         //fuzz inputs
         for (i <- 0 until 100) {
           val row = Some(Math.random)
-          val coords = projection.project(row, 0, 100)
+          val coords = projection.project(row, 0, 99)
           assert(coords.isDefined)
 
           //check zoom level
@@ -60,7 +60,7 @@ class SeriesProjectionSpec extends FunSpec {
         //fuzz inputs
         for (i <- 0 until 100) {
           val row = Some(Math.random)
-          val coords = projection.project(row, 1, 100)
+          val coords = projection.project(row, 1, 99)
           assert(coords.isDefined)
 
           //check zoom level
@@ -82,7 +82,7 @@ class SeriesProjectionSpec extends FunSpec {
         //fuzz inputs
         for (i <- 0 until 100) {
           val bin = Math.round(Math.random*99).toInt
-          assert(projection.binTo1D(bin, 100) === bin)
+          assert(projection.binTo1D(bin, 99) === bin)
         }
       }
     }


### PR DESCRIPTION
This was due to accidentally using maxBin as tile size (when in fact it is less than the tile size by 1 in each dimension).

Fixes #18 
